### PR TITLE
fix tox.ini for tox4

### DIFF
--- a/{{ cookiecutter.name }}/tox.ini
+++ b/{{ cookiecutter.name }}/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist = py37, linters, integration
-skipsdist = true
+skipsdist = false
 
 [testenv]
 basepython = python3.7
-usedevelop = true
+use_develop = true
 install_command = python -m pip install {env:REQUIREMENTS:} {env:CONSTRAINT:} {opts} {packages}
 setenv =
     REQUIREMENTS = -r requirements.txt
@@ -45,7 +45,7 @@ commands_pre =
     docker build -t wazoplatform/{{ cookiecutter.name }}:local .
 commands =
     pytest {posargs:integration_tests/suite}
-whitelist_externals =
+allowlist_externals =
     docker
 
 [flake8]


### PR DESCRIPTION
Why:

* `whitelist_externals` is now `allowlist_externals`
* `skipsdist` = true and `usedevelop` are now mutually exclusive
* `usedevelop` is now `use_develop`